### PR TITLE
Add substring matching modes to one_of function

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ def test_replies(conversation_factory):
 
 - `contains(actual, substring, *, case_sensitive=False)`: substring search. Case-insensitive by default.
 - `regex(actual, pattern, *, flags=0)`: `re.search` semantics. Returns the match object so callers can inspect captured groups.
-- `one_of(actual, options, *, case_sensitive=False)`: exact equality against a list of alternatives. Use for deterministic varying replies like `["yes", "yeah", "yep"]`.
+- `one_of(actual, options, *, case_sensitive=False, mode="exact")`: matches `actual` against a list of alternative `options`. Supports `mode="exact"` (full-string match, default) and `mode="substring"` (checks if any option is a substring of `actual`).
 
 Use these when bare `assert "hello" in convo.last.bot` would give noisy failure messages across many tests. For one-off checks, plain `assert` is still fine.
 

--- a/src/pytest_conversational/expect.py
+++ b/src/pytest_conversational/expect.py
@@ -14,6 +14,7 @@ the message, so pytest output shows what the bot said versus what was
 expected. Use these instead of bare ``assert`` when you want clear
 diff-style failure output across many tests.
 """
+
 from __future__ import annotations
 
 import re
@@ -30,9 +31,7 @@ def contains(actual: str, substring: str, *, case_sensitive: bool = False) -> No
         AssertionError: if ``actual`` is None or does not contain ``substring``.
     """
     if actual is None:
-        raise AssertionError(
-            f"expected substring {substring!r} in reply, got None"
-        )
+        raise AssertionError(f"expected substring {substring!r} in reply, got None")
     if not isinstance(substring, str):
         raise TypeError(f"substring must be str, got {type(substring).__name__}")
     haystack = actual if case_sensitive else actual.lower()
@@ -53,42 +52,61 @@ def regex(actual: str, pattern: str, *, flags: int = 0) -> re.Match[str]:
         re.error: if ``pattern`` is not a valid regex.
     """
     if actual is None:
-        raise AssertionError(
-            f"expected regex {pattern!r} to match, got None"
-        )
+        raise AssertionError(f"expected regex {pattern!r} to match, got None")
     match = re.search(pattern, actual, flags=flags)
     if match is None:
-        raise AssertionError(
-            f"expected regex {pattern!r} to match, got: {actual!r}"
-        )
+        raise AssertionError(f"expected regex {pattern!r} to match, got: {actual!r}")
     return match
 
 
-def one_of(actual: str, options: Iterable[str], *, case_sensitive: bool = False) -> None:
-    """Assert that ``actual`` is exactly equal to one of ``options``.
+def one_of(
+    actual: str,
+    options: Iterable[str],
+    *,
+    case_sensitive: bool = False,
+    mode: str = "exact",
+) -> None:
+    """Assert that ``actual`` matches one of ``options``.
 
     Use this when the bot replies vary across deterministic alternatives,
     for example ``["yes", "yeah", "yep"]`` for affirmative answers.
-    Compares full strings, not substrings. For substring search across
-    several alternatives, call ``contains`` in a loop or use ``regex``.
 
     Case-insensitive by default. Pass ``case_sensitive=True`` for exact
     case matching.
 
+    Modes:
+        - "exact" (default): full-string exact match.
+        - "substring": substring match.
+
     Raises:
         AssertionError: if ``actual`` is None or matches no option.
-        ValueError: if ``options`` is empty.
+        ValueError: if ``options`` is empty or ``mode`` is invalid.
     """
     opts = list(options)
     if not opts:
         raise ValueError("one_of requires at least one option")
     if actual is None:
-        raise AssertionError(
-            f"expected reply to be one of {opts!r}, got None"
+        raise AssertionError(f"expected reply to match one of {opts!r}, got None")
+
+    if not case_sensitive:
+        actual_cmp = actual.lower()
+        opts_cmp = [o.lower() for o in opts]
+    else:
+        actual_cmp = actual
+        opts_cmp = opts
+
+    if mode == "exact":
+        matched = actual_cmp in opts_cmp
+
+    elif mode == "substring":
+        matched = any(option in actual_cmp for option in opts_cmp)
+
+    else:
+        raise ValueError(
+            f"invalid mode for one_of: {mode!r}. Supported modes are: 'exact', 'substring'"
         )
-    target = actual if case_sensitive else actual.lower()
-    candidates = opts if case_sensitive else [o.lower() for o in opts]
-    if target not in candidates:
+
+    if not matched:
         raise AssertionError(
-            f"expected reply to be one of {opts!r}, got: {actual!r}"
+            f"expected reply to match one of {opts!r} using mode={mode!r}, case_sensitive={case_sensitive}, got: {actual!r}"
         )

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -1,4 +1,5 @@
 """Tests for the expect matchers module."""
+
 from __future__ import annotations
 
 import re
@@ -83,11 +84,11 @@ class TestOneOf:
         expect.one_of("yep", ["yes", "yeah", "yep"])
 
     def test_no_match_raises(self) -> None:
-        with pytest.raises(AssertionError, match="expected reply to be one of"):
+        with pytest.raises(AssertionError, match="expected reply to match one of"):
             expect.one_of("maybe", ["yes", "no"])
 
-    def test_substring_match_does_not_count(self) -> None:
-        # one_of requires full equality. "yeshere" contains "yes" but is not "yes".
+    def test_substring_match_does_not_count_in_exact_mode(self) -> None:
+        # one_of requires full equality by default (exact mode).
         with pytest.raises(AssertionError):
             expect.one_of("yeshere", ["yes", "no"])
 
@@ -98,6 +99,23 @@ class TestOneOf:
         expect.one_of("yes", ["yes", "no"], case_sensitive=True)
         with pytest.raises(AssertionError):
             expect.one_of("YES", ["yes", "no"], case_sensitive=True)
+
+    def test_substring_mode_matches_substring(self) -> None:
+        expect.one_of("hello there", ["hello", "bye"], mode="substring")
+        expect.one_of("hello there", ["hi", "there"], mode="substring")
+
+    def test_substring_mode_case_sensitive(self) -> None:
+        with pytest.raises(AssertionError):
+            expect.one_of(
+                "HELLO there", ["hello", "bye"], mode="substring", case_sensitive=True
+            )
+
+    def test_substring_mode_case_insensitive_by_default(self) -> None:
+        expect.one_of("HELLO there", ["hello", "bye"], mode="substring")
+
+    def test_invalid_mode_raises_valueerror(self) -> None:
+        with pytest.raises(ValueError, match="invalid mode for one_of"):
+            expect.one_of("yes", ["yes"], mode="regex")
 
     def test_none_actual_raises(self) -> None:
         with pytest.raises(AssertionError, match="got None"):
@@ -115,6 +133,8 @@ class TestOneOf:
             assert "nope" in msg
             assert "yes" in msg
             assert "yeah" in msg
+            assert "mode='exact'" in msg
+            assert "case_sensitive=False" in msg
         else:
             pytest.fail("expected AssertionError")
 


### PR DESCRIPTION
## Summary

Adds support for substring-based matching in `one_of()`.

### Changes
- Added `mode="substring"` for case-sensitive substring matching
- Added validation for unsupported modes
- Updated assertion messages to include the mode used
- Added unit tests covering all new matching modes and invalid mode handling
- Updated README documentation for supported modes

Closes #3