### PR TITLE
docs: add 3 example chatbot tests

### DIFF
--- a/examples/test_faq_bot.py
+++ b/examples/test_faq_bot.py
@@ -1,0 +1,24 @@
+from pytest_conversational import expect
+
+def faq_bot(text, convo):
+    text = text.lower()
+    if "hi" in text or "hello" in text:
+        return "Hello! How can I help you today?"
+    if "hours" in text:
+        return "We are open 9am-5pm, Monday to Friday."
+    if "refund" in text:
+        return "Refunds take 5-7 business days to process."
+    return "I'm sorry, I don't have an answer for that."
+
+def test_greeting_variants(conversation_factory):
+    convo = conversation_factory(bot=faq_bot)
+    
+    convo.say("Hi there")
+    expect.one_of(convo.last.bot, ["Hello! How can I help you today?", "Hi!"])
+
+def test_store_hours(conversation_factory):
+    convo = conversation_factory(bot=faq_bot)
+    
+    convo.say("What are your hours?")
+    expect.regex(convo.last.bot, r"\d[ap]m-\d[ap]m")
+    expect.contains(convo.last.bot, "Monday")

--- a/examples/test_order_bot.py
+++ b/examples/test_order_bot.py
@@ -1,0 +1,30 @@
+import re
+from pytest_conversational import expect
+
+def order_bot(text, convo):
+    # Match order ID pattern: ORD-12345
+    match = re.search(r"ORD-(\d{5})", text.upper())
+    if match:
+        order_num = match.group(1)
+        return f"Order {order_num} is currently out for delivery."
+    
+    if "order" in text.lower():
+        return "Please provide your order ID in the format ORD-XXXXX."
+    
+    return "I can help you track orders. Just say 'track ORD-12345'."
+
+def test_order_tracking_success(conversation_factory):
+    convo = conversation_factory(bot=order_bot)
+    
+    convo.say("Track my order ORD-99887")
+    expect.contains(convo.last.bot, "99887")
+    expect.contains(convo.last.bot, "delivery")
+
+def test_order_invalid_format(conversation_factory):
+    convo = conversation_factory(bot=order_bot)
+    
+    convo.say("I want to track an order")
+    expect.contains(convo.last.bot, "format ORD-XXXXX")
+
+    convo.say("My ID is 12345") # Missing prefix
+    expect.contains(convo.last.bot, "track ORD-12345")

--- a/examples/test_weather_bot.py
+++ b/examples/test_weather_bot.py
@@ -1,0 +1,41 @@
+from pytest_conversational import expect
+
+def weather_bot(text, convo):
+    """A bot that asks for a city if not provided in the first turn."""
+    state = convo.state
+    text = text.lower()
+    
+    if "weather" in text:
+        if "in" in text:
+            city = text.split("in")[-1].strip()
+            state["city"] = city
+            return f"The weather in {city} is sunny."
+        return "Which city are you interested in?"
+    
+    # Check previous turns for context
+    if len(convo.turns) > 1 and "Which city" in convo.turns[-2].bot:
+        state["city"] = text
+        return f"The weather in {text} is sunny."
+        
+    return "I only know about the weather. Ask me 'weather in London'."
+
+def test_weather_flow(conversation_factory):
+    convo = conversation_factory(bot=weather_bot)
+    
+    # Turn 1: Partial request
+    convo.say("what is the weather?")
+    assert "Which city" in convo.last.bot
+    
+    # Turn 2: Providing the slot
+    convo.say("London")
+    assert convo.state["city"] == "london"
+    expect.contains(convo.last.bot, "sunny")
+    expect.contains(convo.last.bot, "London")
+
+def test_weather_direct(conversation_factory):
+    convo = conversation_factory(bot=weather_bot)
+    
+    # Turn 1: Full request
+    convo.say("weather in Paris")
+    assert convo.state["city"] == "paris"
+    expect.contains(convo.last.bot, "Paris")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,5 @@ pytest_conversational = "pytest_conversational.plugin"
 packages = ["src/pytest_conversational"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "examples"]
 python_files = "test_*.py"


### PR DESCRIPTION
This PR adds three example tests under the `examples/` folder as suggested in Issue #4. These examples demonstrate:
- **Weather Bot**: Multi-turn state management and slot filling.
- **FAQ Bot**: Use of `expect.one_of` and `expect.regex` matchers.
- **Order Tracking Bot**: Input validation using regex and fallback responses.

All examples were verified locally using a fresh virtual environment.