### PR TITLE
feat: marker-driven scenario parametrization (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@pytest.mark.conversational(data="cases.yaml")` generates one test per
+  scenario in a YAML or JSON file (issue #1). The marker reads the file through
+  the existing `load_scenarios` loader and parametrizes the test's `scenario`
+  argument (one row per case, id = scenario `name`, visible in
+  `--collect-only`). A case may name fixtures to override under a `fixtures:`
+  block, resolved per case through the new `scenario_fixtures` fixture, so a
+  different bot adapter can be used per locale. A bare
+  `@pytest.mark.conversational` (no `data=`) stays a plain tag. YAML still loads
+  only through the optional `[scenarios]` extra, so the core stays
+  zero-dependency, and a malformed file fails collection with a clear
+  `ScenarioLoadError` message rather than a stack trace.
 - `Conversation.say_async(text)`, an async counterpart of `say` for coroutine
   bot adapters. It awaits the adapter's reply and keeps the same turn ordering,
   `convo.history` contract, and partial-transcript-on-failure semantics as the

--- a/README.md
+++ b/README.md
@@ -70,6 +70,47 @@ def test_two_slot_flow(conversation_factory):
     assert convo.last.bot == "hello Mikhail from Hove"
 ```
 
+## Data-driven scenarios
+
+Repetitive dialogues - the same shape with different inputs (greetings per language, slot variants, fallback phrasings) - load from a YAML or JSON file and run as one test per case. Mark the test with `data=` and take a `scenario` argument:
+
+```python
+import pytest
+from pytest_conversational import expect
+
+@pytest.mark.conversational(data="tests/data/order_status.yaml")
+def test_order_status(scenario, scenario_fixtures, conversation_factory):
+    convo = conversation_factory(bot=scenario_fixtures["bot"])
+    for turn in scenario.turns:
+        convo.say(turn.user)
+        if turn.expect_contains:
+            expect.contains(convo.last.bot, turn.expect_contains)
+```
+
+```yaml
+# tests/data/order_status.yaml
+- name: english_path
+  fixtures: { bot: english_bot }     # a fixture per case (e.g. a locale bot)
+  turns:
+    - user: "where is my order?"
+      expect_contains: "order number"
+- name: russian_path
+  fixtures: { bot: russian_bot }
+  turns:
+    - user: "gde moy zakaz?"
+      expect_contains: "nomer zakaza"
+```
+
+Each case becomes its own test, with the scenario `name` as the pytest id (visible in `pytest --collect-only`). The file is data, not behaviour: the test keeps control of the assertions, and a case's `fixtures` overrides resolve to live fixtures through `scenario_fixtures`. A malformed file (missing `name`/`turns`, a non-mapping `fixtures`) fails collection with a clear message rather than a stack trace.
+
+JSON works out of the box; YAML needs the optional extra:
+
+```bash
+pip install pytest-conversational[scenarios]
+```
+
+The decorator form `@parametrize_scenarios("cases.yaml")` is also available for tests that prefer a parametrize-style API over the marker.
+
 ## HTTP webhook adapter
 
 If your bot lives behind an HTTP endpoint, use the bundled adapter instead of writing one by hand:

--- a/src/pytest_conversational/plugin.py
+++ b/src/pytest_conversational/plugin.py
@@ -1,5 +1,6 @@
 """pytest plugin entry. Provides the ``conversation`` fixture and a builder."""
 
+import warnings
 from typing import Callable, Optional
 
 import pytest
@@ -10,6 +11,7 @@ from pytest_conversational.allure_attachments import (
     attach_to_allure,
 )
 from pytest_conversational.conversation import BotAdapter, Conversation
+from pytest_conversational.scenarios import load_scenarios
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -25,8 +27,84 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     config.addinivalue_line(
         "markers",
-        "conversational: tag a test as a multi-turn conversational bot test",
+        "conversational: tag a test as a multi-turn conversational bot test. "
+        "Pass data='path.json|yaml' to generate one test per scenario in the file.",
     )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Generate one test per scenario for ``@pytest.mark.conversational(data=...)``.
+
+    The marker doubles as a parametrize source: with ``data=`` pointing at a
+    ``.json``/``.yaml`` scenario file, this loads the scenarios and parametrizes
+    the test's ``scenario`` argument (one row per case, id = scenario name). A
+    bare ``@pytest.mark.conversational`` (no ``data=``) stays a plain tag.
+
+    ``argname`` overrides the parametrized name when ``scenario`` collides with
+    an existing fixture. Parametrization is indirect so the ``scenario`` fixture
+    (and ``scenario_fixtures``) can read the active case. A malformed file raises
+    ``ScenarioLoadError`` here, surfacing as a clear collection error rather than
+    a stack trace deep in the test body.
+    """
+    marker = metafunc.definition.get_closest_marker("conversational")
+    if marker is None:
+        return
+    data = marker.kwargs.get("data")
+    if data is None:
+        return
+    argname = marker.kwargs.get("argname", "scenario")
+    if argname not in metafunc.fixturenames:
+        warnings.warn(
+            f"@pytest.mark.conversational(data={data!r}) is set but the test "
+            f"{metafunc.function.__name__!r} takes no {argname!r} argument, so no "
+            f"scenarios were generated. Add {argname!r} to the test signature, or "
+            f"pass argname= to match an existing parameter.",
+            stacklevel=2,
+        )
+        return
+    scenarios = load_scenarios(data)
+    metafunc.parametrize(
+        argname,
+        scenarios,
+        ids=[s.name for s in scenarios],
+        indirect=True,
+    )
+
+
+@pytest.fixture
+def scenario(request: pytest.FixtureRequest):
+    """The scenario for the current ``@pytest.mark.conversational(data=...)`` row.
+
+    Populated by ``pytest_generate_tests`` via indirect parametrization, so it
+    only resolves inside a marker-parametrized test. The test walks
+    ``scenario.turns`` itself: the file is data, the test keeps the behaviour.
+    """
+    if not hasattr(request, "param"):
+        raise pytest.UsageError(
+            "the 'scenario' fixture only resolves inside a test marked "
+            "@pytest.mark.conversational(data='...'); add the marker, or use "
+            "parametrize_scenarios(...) for the decorator-style API."
+        )
+    return request.param
+
+
+@pytest.fixture
+def scenario_fixtures(request: pytest.FixtureRequest, scenario) -> dict:
+    """Resolve the per-case fixture overrides declared in ``scenario.fixtures``.
+
+    Each ``{role: fixture_name}`` entry becomes ``{role: <live fixture value>}``,
+    so a case can swap, say, the bot adapter per locale::
+
+        # cases.yaml: - name: ru, fixtures: {bot: russian_bot}, turns: [...]
+        def test_flow(scenario, scenario_fixtures, conversation_factory):
+            convo = conversation_factory(bot=scenario_fixtures["bot"])
+
+    A scenario with no overrides yields an empty mapping.
+    """
+    return {
+        role: request.getfixturevalue(name)
+        for role, name in scenario.fixtures.items()
+    }
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/src/pytest_conversational/scenarios.py
+++ b/src/pytest_conversational/scenarios.py
@@ -54,6 +54,7 @@ class Scenario:
     name: str
     turns: tuple[ScenarioTurn, ...]
     tags: tuple[str, ...] = ()
+    fixtures: dict[str, str] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -115,7 +116,21 @@ def _coerce_scenario(raw: Any, index: int) -> Scenario:
     metadata = raw.get("metadata") or {}
     if not isinstance(metadata, dict):
         raise ScenarioLoadError(f"scenario {name!r}: 'metadata' must be a mapping")
-    return Scenario(name=name, turns=turns, tags=tuple(tags_raw), metadata=metadata)
+    fixtures_raw = raw.get("fixtures") or {}
+    if not isinstance(fixtures_raw, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in fixtures_raw.items()
+    ):
+        raise ScenarioLoadError(
+            f"scenario {name!r}: 'fixtures' must be a mapping of fixture role to "
+            f"fixture name (strings), e.g. {{'bot': 'russian_bot'}}"
+        )
+    return Scenario(
+        name=name,
+        turns=turns,
+        tags=tuple(tags_raw),
+        fixtures=dict(fixtures_raw),
+        metadata=metadata,
+    )
 
 
 def _parse_json(text: str) -> Any:

--- a/tests/test_marker_parametrize.py
+++ b/tests/test_marker_parametrize.py
@@ -1,0 +1,189 @@
+"""Marker-driven scenario parametrization (#1).
+
+``@pytest.mark.conversational(data="cases.json")`` loads the scenario file and
+generates one test per case (id = scenario name), and a case may name fixtures
+to override (e.g. a different bot adapter per locale). These run through
+``pytester`` so they exercise the real entry-point wiring a user gets.
+"""
+
+
+def test_marker_parametrizes_one_test_per_case(pytester):
+    pytester.makefile(
+        ".json",
+        cases='[{"name": "alpha", "turns": [{"user": "hi"}]}, '
+        '{"name": "beta", "turns": [{"user": "yo"}]}]',
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="cases.json")
+        def test_flow(scenario):
+            assert scenario.name in ("alpha", "beta")
+            assert scenario.turns[0].user in ("hi", "yo")
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(passed=2)
+
+
+def test_each_case_id_is_the_scenario_name(pytester):
+    pytester.makefile(
+        ".json",
+        cases='[{"name": "english_path", "turns": [{"user": "hi"}]}, '
+        '{"name": "russian_path", "turns": [{"user": "hi"}]}]',
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="cases.json")
+        def test_flow(scenario):
+            pass
+        """
+    )
+    result = pytester.runpytest("--collect-only", "-q")
+    result.stdout.fnmatch_lines(
+        ["*test_flow*english_path*", "*test_flow*russian_path*"]
+    )
+
+
+def test_per_case_bot_fixture_override(pytester):
+    pytester.makefile(
+        ".json",
+        cases='[{"name": "en", "fixtures": {"bot": "en_bot"}, '
+        '"turns": [{"user": "hi", "expect_contains": "hello"}]}, '
+        '{"name": "ru", "fixtures": {"bot": "ru_bot"}, '
+        '"turns": [{"user": "privet", "expect_contains": "zdrav"}]}]',
+    )
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.fixture
+        def en_bot():
+            return lambda text, convo: "hello there"
+
+        @pytest.fixture
+        def ru_bot():
+            return lambda text, convo: "zdravstvuyte"
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+        from pytest_conversational import expect
+
+        @pytest.mark.conversational(data="cases.json")
+        def test_flow(scenario, scenario_fixtures, conversation_factory):
+            convo = conversation_factory(bot=scenario_fixtures["bot"])
+            for turn in scenario.turns:
+                convo.say(turn.user)
+                if turn.expect_contains:
+                    expect.contains(convo.last.bot, turn.expect_contains)
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(passed=2)
+
+
+def test_scenario_without_overrides_has_empty_fixtures(pytester):
+    pytester.makefile(
+        ".json",
+        cases='[{"name": "plain", "turns": [{"user": "hi"}]}]',
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="cases.json")
+        def test_flow(scenario, scenario_fixtures):
+            assert scenario.fixtures == {}
+            assert scenario_fixtures == {}
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(passed=1)
+
+
+def test_malformed_fixtures_block_gives_clear_error(pytester):
+    pytester.makefile(
+        ".json",
+        bad='[{"name": "x", "fixtures": "not-a-mapping", "turns": [{"user": "hi"}]}]',
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="bad.json")
+        def test_flow(scenario):
+            pass
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*fixtures*mapping*"])
+
+
+def test_missing_data_file_gives_clear_error(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="nope.json")
+        def test_flow(scenario):
+            pass
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*not found*"])
+
+
+def test_marker_without_data_is_still_a_plain_tag(pytester):
+    """A bare ``@pytest.mark.conversational`` (no data=) must not try to load."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational
+        def test_tagged(conversation):
+            conversation.add_user("hi")
+            assert len(conversation.turns) == 1
+        """
+    )
+    result = pytester.runpytest("-q", "--strict-markers")
+    result.assert_outcomes(passed=1)
+
+
+def test_scenario_fixture_outside_marker_gives_clear_error(pytester):
+    """Requesting ``scenario`` with no data marker errors with guidance, not a
+    raw AttributeError into plugin internals."""
+    pytester.makepyfile(
+        """
+        def test_no_marker(scenario):
+            pass
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.stdout.fnmatch_lines(["*conversational(data*"])
+
+
+def test_data_marker_without_scenario_arg_warns(pytester):
+    """``data=`` set but the test forgot the ``scenario`` arg would silently
+    produce one un-parametrized test; warn so the typo is not masked."""
+    pytester.makefile(
+        ".json",
+        cases='[{"name": "a", "turns": [{"user": "hi"}]}]',
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.conversational(data="cases.json")
+        def test_forgot_arg():
+            pass
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.stdout.fnmatch_lines(["*takes no*scenario*"])


### PR DESCRIPTION
Closes #1.

`@pytest.mark.conversational(data="cases.yaml")` generates one test per scenario in a YAML or JSON file (id = scenario name, visible in `--collect-only`), building on the existing `load_scenarios` loader. A case can override fixtures under a `fixtures:` block (e.g. a different bot adapter per locale), resolved through the new `scenario_fixtures` fixture. A bare `@pytest.mark.conversational` (no `data=`) stays a plain tag.

JSON works out of the box; YAML keeps the optional `[scenarios]` extra, so the core stays zero-dependency. A malformed file fails collection with a clear `ScenarioLoadError` instead of a stack trace.

- 9 new pytester tests: parametrization, per-case fixture override, schema validation, and the bare-marker / missing-arg edge cases.
- Full suite: 179 passed, ruff clean.
- README "Data-driven scenarios" section + CHANGELOG entry.

AC: data= accepts .yaml/.json; one test id per case; per-case fixture override; clear validation error on malformed schema.